### PR TITLE
カテゴリCSV登録画面にて、「商品」から「カテゴリ」に更新

### DIFF
--- a/assets/tmpl/moc/product/csv/category/index.pug
+++ b/assets/tmpl/moc/product/csv/category/index.pug
@@ -35,7 +35,7 @@ block primaryContents
                         th.w-25.align-middle.table-ec-lightGray カテゴリID
                         td.align-middle 新規登録時は未設定
                             br
-                            | 既存商品の更新は商品IDを設定
+                            | 既存カテゴリの更新はカテゴリIDを設定
                     tr
                         th.w-25.align-middle.table-ec-lightGray カテゴリ名
                             span.badge.badge-primary.ml-1 必須


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
・カテゴリ登録CSVファイルフォーマットのところにあるカテゴリＩＤの説明を修正
　　⇒「 既存商品の更新は商品IDを設定」を「 既存カテゴリの更新はカテゴリIDを設定」に修正